### PR TITLE
POSIX shell functions support

### DIFF
--- a/ftplugin/sh/StlShowFunc_sh.vim
+++ b/ftplugin/sh/StlShowFunc_sh.vim
@@ -18,69 +18,42 @@ let b:loaded_StlShowFunc_sh= "v2f"
 " StlShowFunc_sh: show function name associated with the line under the cursor {{{1
 "DechoTabOn
 fun! StlShowFunc_sh()
-"  call Dfunc("StlShowFunc_sh() line#".line(".")." mode=".mode())
-  if mode() != 'n'
-"   call Dret("StlShowFunc_sh")
-   return
-  endif
-
-  if !exists("b:shshowfunc_bgn")
-   let b:shshowfunc_bgn= -2
-   let b:shshowfunc_end= -2
-  endif
-
+"  call Dfunc("StlShowFunc_sh() line#" . line(".") . " mode=" . mode())
   let curlinenum = line(".")
-  let swp        = SaveWinPosn(0)
-  if getline(".") =~ '^\s*function\>'
-   let bgnfuncline = line(".")
-  else
-   sil! keepj let bgnfuncline= search('^\s*function\>','bW')
-  endif
-"  call Decho("preliminary bgnfuncline=".bgnfuncline)
-  if bgnfuncline > 0
-   sil! keepj let shfuncstart= search('^\s*{','W')
-   if shfuncstart != 0
-	sil! keepj let endfuncline= searchpair('{','','}',"Wn")
-	if endfuncline <= 0
-	 let bgnfuncline= 0
-	endif
-   else
-	let bgnfuncline = 0
-	let endfuncline = 0
-   endif
-  else
-   let bgnfuncline= 0
-   let endfuncline= 0
-  endif
-  if curlinenum < bgnfuncline || endfuncline < curlinenum
-   let bgnfuncline= 0
-   let endfuncline= 0
-  endif
-  call RestoreWinPosn(swp)
-"  call Decho("previous bgn,end[".b:shshowfunc_bgn.",".b:shshowfunc_end."]")
-"  call Decho("current  bgn,end[".bgnfuncline.",".endfuncline."]")
 
-  if bgnfuncline == b:shshowfunc_bgn && endfuncline == b:shshowfunc_end
+  if   mode() != 'n'
+  \ || exists("w:bgn_range") && exists("w:end_range")
+  \ && w:bgn_range <= curlinenum && curlinenum <= w:end_range
    " looks like we're in the same region -- no change
 "   call Dret("StlShowFunc_sh : no change")
    return
   endif
 
-  let b:shshowfunc_bgn = bgnfuncline
-  let b:shshowfunc_end = endfuncline
-  let endprvfuncline     = search('^}$','Wbn')
-"  call Decho("endprvfuncline=".endprvfuncline)
-
-  if bgnfuncline < endprvfuncline || (endprvfuncline == 0 && bgnfuncline == 0)
-   call StlSetFunc("")
-  else
-   let funcline= getline(bgnfuncline)
-   if funcline =~ '^\s*function\s*\h\w*'
-       let funcname= substitute(funcline,'^\s*function\s*\(\h\w*\).\{-}$','\1','')
-"    call Decho("funcname<".funcname.">")
-    call StlSetFunc(funcname."()")
+  let swp = SaveWinPosn(0)
+  let bgnfuncline = search('^\s*\h\w*\s*()[[:blank:]\n]*{','bWc')
+  let w:bgn_range = bgnfuncline
+"  call Decho("preliminary bgnfuncline=" . bgnfuncline)
+  if bgnfuncline
+   call search('{','W')
+   let endfuncline = searchpair('{','','}',"Wn")
+   if endfuncline < curlinenum
+    let bgnfuncline = 0
+    if endfuncline
+     let w:bgn_range = endfuncline + 1
+    endif
+    let endfuncline = search('^\s*\h\w*\s*()[[:blank:]\n]*{','Wn')
+    let w:end_range = endfuncline ? endfuncline - 1 : line('$')
+   else
+    let w:end_range = endfuncline
    endif
+  else
+   let endfuncline = search('^\s*\h\w*\s*()[[:blank:]\n]*{','Wn')
+   let w:end_range = endfuncline ? endfuncline - 1 : line('$')
   endif
+  call RestoreWinPosn(swp)
+"  call Decho("current  bgn,end[" . w:bgn_range . "," . w:end_range . "]")
+
+  call StlSetFunc( bgnfuncline ? substitute(getline(bgnfuncline), '^\s*\(\h\w*\).*$', '\1', '') : '' )
 
   " set the status line and return
 "  call Dret("StlShowFunc_sh")


### PR DESCRIPTION
Fixes #1 
- add POSIX-style shell functions definition support:
    func_name () { ... }
- optimized function name search algorithm which runs _much_ faster
- overall cleanup

@ivanalejandro0 can you suggest someone who could review this?
@cecamp @mikeage